### PR TITLE
fix: SDConfig create mutation param project vs urn

### DIFF
--- a/.changeset/silly-glasses-decide.md
+++ b/.changeset/silly-glasses-decide.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sdk': patch
+---
+
+Fix createSDConfig mutation to use "project" urn to initialize, rather than its own "urn" (which does not exist yet).

--- a/schema.graphql
+++ b/schema.graphql
@@ -842,7 +842,7 @@ type Mutation @aws_lambda @aws_cognito_user_pools {
 	createResolver(project: String!, input: ResolverInput!): Resolver
 		@aws_lambda
 		@aws_cognito_user_pools
-	createSDConfig(urn: String!, input: SDConfigInput!): SDConfig
+	createSDConfig(project: String!, input: SDConfigInput!): SDConfig
 		@aws_lambda
 		@aws_cognito_user_pools
 	# Creates a release by freezing a resolvers output

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -288,8 +288,8 @@ export const createResolver = /* GraphQL */ `
   }
 `;
 export const createSDConfig = /* GraphQL */ `
-  mutation CreateSDConfig($urn: String!, $input: SDConfigInput!) {
-    createSDConfig(urn: $urn, input: $input) {
+  mutation CreateSDConfig($project: String!, $input: SDConfigInput!) {
+    createSDConfig(project: $project, input: $input) {
       urn
       name
       createdAt

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -994,7 +994,7 @@ export type CreateResolverMutation = {
 };
 
 export type CreateSDConfigMutationVariables = {
-  urn: string,
+  project: string,
   input: SDConfigInput,
 };
 


### PR DESCRIPTION
See https://github.com/tokens-studio/studio-app/blob/master/lambdas/resolve/src/actions/mutation/create/sdConfig.ts#L13

It expects a "project" param, not a "urn" param. The urn gets generated upon SDConfig creation, the projectUrn is attached from the project that creates it.

see also https://github.com/tokens-studio/studio-app/pull/704