### PR TITLE
Change tokenType to scalar

### DIFF
--- a/.changeset/cyan-balloons-thank.md
+++ b/.changeset/cyan-balloons-thank.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sdk': minor
+---
+
+Change TokenType to be of type string

--- a/schema.graphql
+++ b/schema.graphql
@@ -710,30 +710,7 @@ input TokenSetsFilterInput {
     name: StringFilterInput
 }
 
-enum TokenType {
-    any
-    asset
-    border
-    borderRadius
-    borderWidth
-    boxShadow
-    color
-    composition
-    dimension
-    fontFamilies
-    fontSizes
-    fontWeights
-    letterSpacing
-    lineHeights
-    opacity
-    other
-    paragraphSpacing
-    sizing
-    spacing
-    textCase
-    textDecoration
-    typography
-}
+scalar TokenType
 
 input TokenTypeFilterInput {
     eq: TokenType
@@ -747,6 +724,7 @@ input TokenUpdateInput {
     border: BorderInput
     boxShadow: [BoxShadowInput]
     typography: TypographyInput
+    composition: CompositionInput
     ## Use for scalars or references
     value: String
 }
@@ -764,7 +742,6 @@ union ResolvedTokenValue =
     | Token_scalar
     | Token_typography
     | Token_composition
-    
 
 type Token_composition {
     value: String
@@ -1030,7 +1007,7 @@ type Mutation @aws_api_key @aws_lambda @aws_cognito_user_pools {
         @aws_lambda
         @aws_cognito_user_pools
     # Removes a member from a group in your organization
-    removeMemberFromGroup(group: String!, entity: String!): String
+    removeMemberFromGroup(group: String!, user: String!): String
         @aws_api_key
         @aws_lambda
         @aws_cognito_user_pools

--- a/src/api/mutation.ts
+++ b/src/api/mutation.ts
@@ -2,8 +2,7 @@ import * as mutations from '../graphql/mutations';
 import {
     CreateTokenMutation,
     CreateTokenMutationVariables,
-    TokenInput as GraphqlTokenInput,
-    TokenType
+    TokenInput as GraphqlTokenInput
 } from '../graphqlTypes';
 import { Graphql } from './graphql';
 
@@ -16,7 +15,7 @@ export namespace Mutation {
     export interface ITokenInput {
         description?: string;
         name: string;
-        type: TokenType;
+        type: string;
         metadata: Record<string, any>;
     }
 

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -390,8 +390,8 @@ export const addMemberToGroup = /* GraphQL */ `
   }
 `;
 export const removeMemberFromGroup = /* GraphQL */ `
-  mutation RemoveMemberFromGroup($group: String!, $entity: String!) {
-    removeMemberFromGroup(group: $group, entity: $entity)
+  mutation RemoveMemberFromGroup($group: String!, $user: String!) {
+    removeMemberFromGroup(group: $group, user: $user)
   }
 `;
 export const inviteToOrganization = /* GraphQL */ `

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -143,35 +143,9 @@ export type RawToken = {
   extensions?: string | null,
   setUrn?: string | null,
   metadata?: Metadata | null,
-  type?: TokenType | null,
+  type?: string | null,
   value?: RawTokenValue | null,
 };
-
-export enum TokenType {
-  any = "any",
-  asset = "asset",
-  border = "border",
-  borderRadius = "borderRadius",
-  borderWidth = "borderWidth",
-  boxShadow = "boxShadow",
-  color = "color",
-  composition = "composition",
-  dimension = "dimension",
-  fontFamilies = "fontFamilies",
-  fontSizes = "fontSizes",
-  fontWeights = "fontWeights",
-  letterSpacing = "letterSpacing",
-  lineHeights = "lineHeights",
-  opacity = "opacity",
-  other = "other",
-  paragraphSpacing = "paragraphSpacing",
-  sizing = "sizing",
-  spacing = "spacing",
-  textCase = "textCase",
-  textDecoration = "textDecoration",
-  typography = "typography",
-}
-
 
 export type RawTokenValue = Raw_Token_scalar | Raw_Token_typography | Raw_Token_border | Raw_Token_boxShadow | Raw_Token_composition
 
@@ -450,7 +424,7 @@ export type APIKey = {
 export type TokenInput = {
   description?: string | null,
   name: string,
-  type: TokenType,
+  type: string,
   extensions?: string | null,
   value?: string | null,
   typography?: TypographyInput | null,
@@ -614,6 +588,7 @@ export type TokenUpdateInput = {
   border?: BorderInput | null,
   boxShadow?: Array< BoxShadowInput | null > | null,
   typography?: TypographyInput | null,
+  composition?: CompositionInput | null,
   value?: string | null,
 };
 
@@ -712,8 +687,8 @@ export type TokenFilterInput = {
 };
 
 export type TokenTypeFilterInput = {
-  eq?: TokenType | null,
-  ne?: TokenType | null,
+  eq?: string | null,
+  ne?: string | null,
 };
 
 export type Self = {
@@ -741,7 +716,7 @@ export type ResolvedToken = {
   description?: string | null,
   name?: string | null,
   value?: ResolvedTokenValue | null,
-  type?: TokenType | null,
+  type?: string | null,
 };
 
 export type ResolvedTokenValue = Token_border | Token_boxShadow | Token_scalar | Token_typography | Token_composition
@@ -1058,7 +1033,7 @@ export type CreateTokenMutation = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -1096,7 +1071,7 @@ export type BulkCreateTokenMutation = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -1143,7 +1118,7 @@ export type CreateTokenSetMutation = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -1285,7 +1260,7 @@ export type AddMemberToGroupMutation = {
 
 export type RemoveMemberFromGroupMutationVariables = {
   group: string,
-  entity: string,
+  user: string,
 };
 
 export type RemoveMemberFromGroupMutation = {
@@ -1468,7 +1443,7 @@ export type UpdateTokenMutation = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -1515,7 +1490,7 @@ export type UpdateTokenSetMutation = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -1953,7 +1928,7 @@ export type DeleteTokenMutation = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -2007,7 +1982,7 @@ export type DeleteTokenSetMutation = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -2333,7 +2308,7 @@ export type ConvertToStaticSetMutation = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -2770,7 +2745,7 @@ export type TokenSetQuery = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -2803,7 +2778,7 @@ export type TokenSetsQuery = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } >,
 };
@@ -2824,7 +2799,7 @@ export type TokenQuery = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -2864,7 +2839,7 @@ export type TokensQuery = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -2958,7 +2933,7 @@ export type ResolveQuery = {
         value?: string | null,
       }
     ) | null,
-    type?: TokenType | null,
+    type?: string | null,
   } | null > | null,
 };
 
@@ -3169,7 +3144,7 @@ export type OnCreateTokenSubscription = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -3206,7 +3181,7 @@ export type OnUpdateTokenSubscription = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -3243,7 +3218,7 @@ export type OnDeleteTokenSubscription = {
       __typename: "Metadata",
       createdAt?: string | null,
     } | null,
-    type?: TokenType | null,
+    type?: string | null,
     value: ( {
         __typename: "Raw_Token_scalar",
         value?: string | null,
@@ -3289,7 +3264,7 @@ export type OnCreateTokenSetSubscription = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -3319,7 +3294,7 @@ export type OnUpdateTokenSetSubscription = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };
@@ -3349,7 +3324,7 @@ export type OnDeleteTokenSetSubscription = {
       urn?: string | null,
       extensions?: string | null,
       setUrn?: string | null,
-      type?: TokenType | null,
+      type?: string | null,
     } >,
   } | null,
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,8 +6,7 @@ import {
     Raw_Token_boxShadow,
     Raw_Token_composition,
     Raw_Token_typography,
-    ResolvedToken,
-    TokenType
+    ResolvedToken
 } from '../graphqlTypes';
 import {
     SingleBorderToken,
@@ -53,7 +52,7 @@ export const rawTokenToSingleToken = (
     };
 
     switch (token.type) {
-        case TokenType.boxShadow: {
+        case TokenTypes.BOX_SHADOW: {
             const boxShadowToken = token.value as Raw_Token_boxShadow;
             return {
                 type: TokenTypes.BOX_SHADOW,
@@ -64,7 +63,7 @@ export const rawTokenToSingleToken = (
                 ...extend
             } as SingleBoxShadowToken;
         }
-        case TokenType.border: {
+        case TokenTypes.BORDER: {
             const borderToken = token.value as Raw_Token_border;
             return {
                 type: TokenTypes.BORDER,
@@ -74,7 +73,7 @@ export const rawTokenToSingleToken = (
                 ...extend
             } as SingleBorderToken;
         }
-        case TokenType.typography: {
+        case TokenTypes.TYPOGRAPHY: {
             const typographyToken = token.value as Raw_Token_typography;
             return {
                 type: TokenTypes.TYPOGRAPHY,
@@ -84,7 +83,7 @@ export const rawTokenToSingleToken = (
                 ...extend
             } as SingleTypographyToken;
         }
-        case TokenType.composition: {
+        case TokenTypes.COMPOSITION: {
             const compositionToken = token.value as Raw_Token_composition;
             return {
                 type: TokenTypes.COMPOSITION,


### PR DESCRIPTION
* Change token type to scalar so we can upload custom types. We have issues with multiple token sets that had custom types and could not be uploaded. 
@georgebuciuman Could this affect the plugin ? Are we using the TokenType from the sdk there ? 
@SorsOps 